### PR TITLE
child of a Language component is a string, not a React component

### DIFF
--- a/lib/language.js
+++ b/lib/language.js
@@ -11,7 +11,7 @@ module.exports = React.createClass({
         dangerouslySetInnerHTML: {
           __html: hljs.highlight(
             __language__,
-            React.Children.only(this.props.children),
+            this.props.children,
             true
           ).value
         }


### PR DESCRIPTION
Fixes #4 

I am using React 15.3.0.

I was getting an `Uncaught Invariant Violation: onlyChild must be passed a children with exactly one child.`

Usage:

```
<Java>test</Java>
```

This resolves it.
